### PR TITLE
Add support for Pathfinder 1

### DIFF
--- a/package-config.mjs
+++ b/package-config.mjs
@@ -99,6 +99,25 @@ CONFIG.AIP = {
                     ]
                 }
             ],
+        },
+        {
+            packageName: "pf1",
+            sheetClasses: [
+                {
+                    name: "ItemSheetPF",
+                    fieldConfigs: [
+                        { selector: `input.formula[type="text"]`, showButton: true, allowHotkey: true, dataMode: CONST.AIP.DATA_MODE.ROLL_DATA },
+                        { selector: `textarea.context-text`, showButton: true, allowHotkey: true, dataMode: CONST.AIP.DATA_MODE.ROLL_DATA },
+                    ]
+                },
+                {
+                    name: "ActorSheetPF",
+                    fieldConfigs: [
+                        { selector: `input.formula[type="text"]`, showButton: true, allowHotkey: true, dataMode: CONST.AIP.DATA_MODE.ROLL_DATA },
+                        { selector: `textarea.context-text`, showButton: true, allowHotkey: true, dataMode: CONST.AIP.DATA_MODE.ROLL_DATA },
+                    ]
+                }
+            ],
         }
     ]
 }


### PR DESCRIPTION
This will add support for the Pathfinder 1 system. The HTML classes required aren't in the current release of PF1, but will be in the next one. If testing is desired, I'd recommend downloading the specific commit of the PF1 system with the class tags added, [here](https://gitlab.com/Furyspark/foundryvtt-pathfinder1/-/archive/e8abb626d1e320c1e53925d4c84e765915e6b1e1/foundryvtt-pathfinder1-e8abb626d1e320c1e53925d4c84e765915e6b1e1.zip).