### PR TITLE
Add support for the ds4 (Dungeonslayers 4) system

### DIFF
--- a/package-config.mjs
+++ b/package-config.mjs
@@ -145,6 +145,59 @@ const PACKAGE_CONFIG = [
             }
         ],
     },
+    {
+        packageName: "ds4",
+        sheetClasses: [
+            {
+                name: "ActiveEffectConfig",
+                fieldConfigs: [
+                    {
+                        selector: `.tab[data-tab="effects"] .key input[type="text"]`,
+                        defaultPath: "data",
+                        showButton: true,
+                        allowHotkey: true,
+                        dataMode: DATA_MODE.CUSTOM,
+                        customDataGetter: (sheet) => {
+                            if (!(sheet instanceof ActiveEffectConfig)) return;
+                            if (sheet.object.parent instanceof Actor) {
+                                return sheet.object.parent.data;
+                            } else {
+                                const cls = getDocumentClass("Actor");
+                                const data = {};
+                                for(const type of game.system.template.Actor.types) {
+                                    const actorData = new cls({ type, name: "dummy" }).data;
+                                    foundry.utils.mergeObject(data, actorData)
+                                }
+                                return data;
+                            }
+                        },
+                    },
+                    {
+                        selector: `.tab[data-tab="effects"] .value input[type="text"]`,
+                        defaultPath: "data",
+                        showButton: true,
+                        allowHotkey: true,
+                        dataMode: DATA_MODE.CUSTOM,
+                        customDataGetter: (sheet) => {
+                            if (!(sheet instanceof ActiveEffectConfig)) return;
+                            if (sheet.object.parent instanceof Actor) {
+                                return sheet.object.parent.data;
+                            } else {
+                                const cls = getDocumentClass("Actor");
+                                const data = {};
+                                for(const type of game.system.template.Actor.types) {
+                                    const actorData = new cls({ type, name: "dummy" }).data;
+                                    foundry.utils.mergeObject(data, actorData)
+                                }
+                                return data;
+                            }
+                        },
+                        customInlinePrefix: "@"
+                    },
+                ],
+            },
+        ],
+    },
 ];
 
 Hooks.on("init", () => {


### PR DESCRIPTION
This basically also implements the solution proposed for #1. In order to make it generic, the only thing that would need to be differently is to iterate over all the possible actor types instead of hard coding them.