### PR TITLE
Include Torg Eternity support

### DIFF
--- a/package-config.mjs
+++ b/package-config.mjs
@@ -145,6 +145,37 @@ const PACKAGE_CONFIG = [
             }
         ],
     },
+    {
+        packageName: "torgeternity",
+        sheetClasses: [
+            {
+                name: "ActiveEffectConfig",
+                fieldConfigs: [
+                    {
+                        selector: `.tab[data-tab="effects"] .key input[type="text"]`,
+                        defaultPath: "data",
+                        showButton: true,
+                        allowHotkey: true,
+                        dataMode: DATA_MODE.CUSTOM,
+                        customDataGetter: (sheet) => {
+                            if (!(sheet instanceof ActiveEffectConfig)) return;
+                            if (sheet.object.parent instanceof Actor) {
+                                return sheet.object.parent.data;
+                            } else {
+                                const cls = getDocumentClass("Actor");
+                                const data = {};
+                                for(const type of game.system.template.Actor.types) {
+                                    const actorData = new cls({ type, name: "dummy" }).data;
+                                    foundry.utils.mergeObject(data, actorData)
+                                }
+                                return data;
+                            }
+                        },
+                    },
+                ],
+            },
+        ],
+    },
 ];
 
 Hooks.on("init", () => {


### PR DESCRIPTION
Based on https://github.com/schultzcole/FVTT-Autocomplete-Inline-Properties/pull/21 - and as Ghost mentions in that, this is likely a decent generic fallback for any system which uses the ActiveEffectConfig application.

(doesn't include the second part of Ghost's implementation for ds4, as Torg Eternity doesn't seem to support @rolldata in the effect values)